### PR TITLE
fix: 🐛 TypeScript において Jest と Cypress を併用しているときのコンフリクトを解消した

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,6 @@
   },
   "ts-node": {
     "files": true
-  }
+  },
+  "exclude": ["__tests__/*.spec.ts"]
 }


### PR DESCRIPTION
- [cypress-io/cypress-and-jest-typescript-example: Example using Jest and Cypress with TypeScript in a single repo](https://github.com/cypress-io/cypress-and-jest-typescript-example)

> If you are using Jest and Cypress types in the same project, they might conflict because both test runners use globals like expect. This project shows how to isolate Cypress TypeScript definitions from Jest TS definitions in the same project.

- [typescript - Cypress causing type errors in jest assertions - Stack Overflow](https://stackoverflow.com/questions/58999086/cypress-causing-type-errors-in-jest-assertions)

[![Image from Gyazo](https://i.gyazo.com/e8ea2da9c145441ed5c3ceabb3f9e63d.png)](https://gyazo.com/e8ea2da9c145441ed5c3ceabb3f9e63d)

[![Image from Gyazo](https://i.gyazo.com/bad5bdc04a4ac23664fda7597371794c.png)](https://gyazo.com/bad5bdc04a4ac23664fda7597371794c)
